### PR TITLE
fix: convert sequence into vector of bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",

--- a/tracerbench-serve/Cargo.toml
+++ b/tracerbench-serve/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pretty_env_logger = ""
+pretty_env_logger = "0.3.1"
 structopt = "0.3"
 tokio = { version = "1.5", features = ["full"] }
 tracerbench-recorded-response-server = { path = "../recorded-response-server" }


### PR DESCRIPTION
The latest serde_cbor (0.11.x) doesn't compatible with serde::Deserializer. Add conversion to copy byte array from sequence to vector of bytes.